### PR TITLE
[PR] Fixed: StatusCode cannot be set because the response has already star…

### DIFF
--- a/source/HangfireBasicAuthenticationFilter/HangfireCustomBasicAuthenticationFilter.cs
+++ b/source/HangfireBasicAuthenticationFilter/HangfireCustomBasicAuthenticationFilter.cs
@@ -90,7 +90,6 @@ namespace HangfireBasicAuthenticationFilter
         {
             httpContext.Response.StatusCode = 401;
             httpContext.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"Hangfire Dashboard\"");
-            httpContext.Response.WriteAsync("Authentication is required.");
         }
     }
 }


### PR DESCRIPTION
Current:
401 responses on Kestrell/IIS logs "StatusCode cannot be set because the response has already started."
Fix:
Removed write to response body. 