### PR TITLE
.netcore 6 upgrade

### DIFF
--- a/source/HangfireBasicAuthenticationFilter.Tests/HangfireBasicAuthenticationFilter.Tests.csproj
+++ b/source/HangfireBasicAuthenticationFilter.Tests/HangfireBasicAuthenticationFilter.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/HangfireBasicAuthenticationFilter/HangfireBasicAuthenticationFilter.csproj
+++ b/source/HangfireBasicAuthenticationFilter/HangfireBasicAuthenticationFilter.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Hangfire.Dashboard.Basic.Authentication</PackageId>
     <Authors>Travis Frisinger</Authors>
     <Company>StoneAge Technologies</Company>
     <Description>A re-usable Hangfire Basic Authentication filter. Just import and configure.</Description>
     <PackageProjectUrl>https://github.com/StoneAgeTechnologies/HangfireBasicAuthenticationFilter.git</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.0.0</Version>
-    <PackageReleaseNotes>.net 7 update</PackageReleaseNotes>
-    <FileVersion>7.0.0.0</FileVersion>
-    <AssemblyVersion>7.0.0.0</AssemblyVersion>
+    <Version>6.0.0</Version>
+    <PackageReleaseNotes>.net 6 update</PackageReleaseNotes>
+    <FileVersion>6.0.0.0</FileVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.34" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.34" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi, please check my PR, I've Updated the packages, and targeted dotnet 6.
I Removed **HangFire.Core** because it's existed in **Hangfire.AspNetCore** nuget package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Downgraded project target framework from .NET 7.0 to .NET 6.0
	- Updated package references and versions for testing and core libraries
	- Updated package version to 6.0.0
	- Updated file and assembly versions to match new framework

- **Dependencies**
	- Upgraded Hangfire.AspNetCore to version 1.8.17
	- Updated NUnit, NUnit3TestAdapter, FluentAssertions, and Microsoft.NET.Test.Sdk to latest compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->